### PR TITLE
Move API versioning to headers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG DOCKER_HUB
 
-FROM ${DOCKER_HUB}library/golang:1.24.0-alpine AS builder
+FROM ${DOCKER_HUB}library/golang:1.24.1-alpine AS builder
 
 RUN apk update \
   && apk add bash unzip zip make nodejs npm

--- a/README.md
+++ b/README.md
@@ -26,7 +26,20 @@ Knot is a powerful tool to manage Cloud Development Environment within a Nomad c
 - **Support for VNC:** Support for web based VNC servers such as KasmVNC.
 - **Remote Servers** Maximize performance by deploying environment close to developers but manage templates and users from one central location.
 - **Custom Roles:** Create custom roles to manage permissions.
+- **Sharing:** Spaces can be shared with other users allowing SSH and terminal access.
+- **Logging:** Syslog compatible interface allows logging and display within a window.
+- **Tunneling:** Securely expose development environments to the internet when required.
 - **API:** Provides an API for integration with other systems.
+
+## API Versioning
+
+The API version is specified in the request header:
+
+```http
+X-Knot-Api-Version: 2025-03-10
+```
+
+Any non-breaking changes are available in all versions of the API while breaking changes are only available in the latest version of the API.
 
 ## Security
 

--- a/api/apiv1/auth.go
+++ b/api/apiv1/auth.go
@@ -196,7 +196,7 @@ func HandleAuthorization(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Only create the cookie for web auth
-	if r.URL.Path == "/api/v1/auth/web" {
+	if r.URL.Path == "/api/auth/web" {
 		cookie := &http.Cookie{
 			Name:     model.WEBUI_SESSION_COOKIE,
 			Value:    session.Id,

--- a/api/apiv1/lookup.go
+++ b/api/apiv1/lookup.go
@@ -46,6 +46,6 @@ func HandleLookup(w http.ResponseWriter, r *http.Request) {
 
 func CallLookup(client *rest.RESTClient, service string) (*LookupResponse, int, error) {
 	lookup := &LookupResponse{}
-	statusCode, err := client.Get(fmt.Sprintf("/api/v1/lookup/%s", service), lookup)
+	statusCode, err := client.Get(fmt.Sprintf("/api/lookup/%s", service), lookup)
 	return lookup, statusCode, err
 }

--- a/api/apiv1/routes.go
+++ b/api/apiv1/routes.go
@@ -11,97 +11,97 @@ import (
 func ApiRoutes(router *http.ServeMux) {
 
 	// Core
-	router.HandleFunc("GET /api/v1/lookup/{service}", middleware.ApiAuth(HandleLookup))
-	router.HandleFunc("GET /api/v1/ping", middleware.ApiAuth(HandlePing))
-	router.HandleFunc("POST /api/v1/auth/logout", middleware.ApiAuth(HandleLogout))
+	router.HandleFunc("GET /api/lookup/{service}", middleware.ApiAuth(HandleLookup))
+	router.HandleFunc("GET /api/ping", middleware.ApiAuth(HandlePing))
+	router.HandleFunc("POST /api/auth/logout", middleware.ApiAuth(HandleLogout))
 
 	// Users
-	router.HandleFunc("GET /api/v1/users", middleware.ApiAuth(middleware.ApiPermissionManageUsersOrSpaces(HandleGetUsers)))
-	router.HandleFunc("POST /api/v1/users", middleware.ApiAuth(middleware.ApiPermissionManageUsers(HandleCreateUser)))
-	router.HandleFunc("GET /api/v1/users/whoami", middleware.ApiAuth(HandleWhoAmI))
-	router.HandleFunc("GET /api/v1/users/{user_id}", middleware.ApiAuth(middleware.ApiPermissionManageUsersOrSelf(HandleGetUser)))
-	router.HandleFunc("PUT /api/v1/users/{user_id}", middleware.ApiAuth(middleware.ApiPermissionManageUsersOrSelf(HandleUpdateUser)))
-	router.HandleFunc("DELETE /api/v1/users/{user_id}", middleware.ApiAuth(middleware.ApiPermissionManageUsersOrSelf(HandleDeleteUser)))
-	router.HandleFunc("GET /api/v1/users/{user_id}/quota", middleware.ApiAuth(middleware.ApiPermissionManageUsersOrSelf(HandleGetUserQuota)))
+	router.HandleFunc("GET /api/users", middleware.ApiAuth(middleware.ApiPermissionManageUsersOrSpaces(HandleGetUsers)))
+	router.HandleFunc("POST /api/users", middleware.ApiAuth(middleware.ApiPermissionManageUsers(HandleCreateUser)))
+	router.HandleFunc("GET /api/users/whoami", middleware.ApiAuth(HandleWhoAmI))
+	router.HandleFunc("GET /api/users/{user_id}", middleware.ApiAuth(middleware.ApiPermissionManageUsersOrSelf(HandleGetUser)))
+	router.HandleFunc("PUT /api/users/{user_id}", middleware.ApiAuth(middleware.ApiPermissionManageUsersOrSelf(HandleUpdateUser)))
+	router.HandleFunc("DELETE /api/users/{user_id}", middleware.ApiAuth(middleware.ApiPermissionManageUsersOrSelf(HandleDeleteUser)))
+	router.HandleFunc("GET /api/users/{user_id}/quota", middleware.ApiAuth(middleware.ApiPermissionManageUsersOrSelf(HandleGetUserQuota)))
 
 	// Groups
-	router.HandleFunc("GET /api/v1/groups", middleware.ApiAuth(HandleGetGroups))
-	router.HandleFunc("POST /api/v1/groups", middleware.ApiAuth(middleware.ApiPermissionManageGroups(HandleCreateGroup)))
-	router.HandleFunc("PUT /api/v1/groups/{group_id}", middleware.ApiAuth(middleware.ApiPermissionManageGroups(HandleUpdateGroup)))
-	router.HandleFunc("DELETE /api/v1/groups/{group_id}", middleware.ApiAuth(middleware.ApiPermissionManageGroups(HandleDeleteGroup)))
-	router.HandleFunc("GET /api/v1/groups/{group_id}", middleware.ApiAuth(middleware.ApiPermissionManageGroups(HandleGetGroup)))
+	router.HandleFunc("GET /api/groups", middleware.ApiAuth(HandleGetGroups))
+	router.HandleFunc("POST /api/groups", middleware.ApiAuth(middleware.ApiPermissionManageGroups(HandleCreateGroup)))
+	router.HandleFunc("PUT /api/groups/{group_id}", middleware.ApiAuth(middleware.ApiPermissionManageGroups(HandleUpdateGroup)))
+	router.HandleFunc("DELETE /api/groups/{group_id}", middleware.ApiAuth(middleware.ApiPermissionManageGroups(HandleDeleteGroup)))
+	router.HandleFunc("GET /api/groups/{group_id}", middleware.ApiAuth(middleware.ApiPermissionManageGroups(HandleGetGroup)))
 
 	// Permissions
-	router.HandleFunc("GET /api/v1/permissions", middleware.ApiAuth(HandleGetPermissions))
+	router.HandleFunc("GET /api/permissions", middleware.ApiAuth(HandleGetPermissions))
 
 	// Roles
-	router.HandleFunc("GET /api/v1/roles", middleware.ApiAuth(HandleGetRoles))
-	router.HandleFunc("POST /api/v1/roles", middleware.ApiAuth(middleware.ApiPermissionManageRoles(HandleCreateRole)))
-	router.HandleFunc("PUT /api/v1/roles/{role_id}", middleware.ApiAuth(middleware.ApiPermissionManageRoles(HandleUpdateRole)))
-	router.HandleFunc("DELETE /api/v1/roles/{role_id}", middleware.ApiAuth(middleware.ApiPermissionManageRoles(HandleDeleteRole)))
-	router.HandleFunc("GET /api/v1/roles/{role_id}", middleware.ApiAuth(middleware.ApiPermissionManageRoles(HandleGetRole)))
+	router.HandleFunc("GET /api/roles", middleware.ApiAuth(HandleGetRoles))
+	router.HandleFunc("POST /api/roles", middleware.ApiAuth(middleware.ApiPermissionManageRoles(HandleCreateRole)))
+	router.HandleFunc("PUT /api/roles/{role_id}", middleware.ApiAuth(middleware.ApiPermissionManageRoles(HandleUpdateRole)))
+	router.HandleFunc("DELETE /api/roles/{role_id}", middleware.ApiAuth(middleware.ApiPermissionManageRoles(HandleDeleteRole)))
+	router.HandleFunc("GET /api/roles/{role_id}", middleware.ApiAuth(middleware.ApiPermissionManageRoles(HandleGetRole)))
 
 	// Sessions
-	router.HandleFunc("GET /api/v1/sessions", middleware.ApiAuth(HandleGetSessions))
-	router.HandleFunc("DELETE /api/v1/sessions/{session_id}", middleware.ApiAuth(HandleDeleteSessions))
+	router.HandleFunc("GET /api/sessions", middleware.ApiAuth(HandleGetSessions))
+	router.HandleFunc("DELETE /api/sessions/{session_id}", middleware.ApiAuth(HandleDeleteSessions))
 
 	// Tokens
-	router.HandleFunc("GET /api/v1/tokens", middleware.ApiAuth(HandleGetTokens))
-	router.HandleFunc("POST /api/v1/tokens", middleware.ApiAuth(HandleCreateToken))
-	router.HandleFunc("DELETE /api/v1/tokens/{token_id}", middleware.ApiAuth(HandleDeleteToken))
+	router.HandleFunc("GET /api/tokens", middleware.ApiAuth(HandleGetTokens))
+	router.HandleFunc("POST /api/tokens", middleware.ApiAuth(HandleCreateToken))
+	router.HandleFunc("DELETE /api/tokens/{token_id}", middleware.ApiAuth(HandleDeleteToken))
 
 	// Spaces
-	router.HandleFunc("GET /api/v1/spaces", middleware.ApiAuth(middleware.ApiPermissionUseSpaces(HandleGetSpaces)))
-	router.HandleFunc("POST /api/v1/spaces", middleware.ApiAuth(middleware.ApiPermissionUseSpaces(HandleCreateSpace)))
-	router.HandleFunc("PUT /api/v1/spaces/{space_id}", middleware.ApiAuth(middleware.ApiPermissionUseSpaces(HandleUpdateSpace)))
-	router.HandleFunc("DELETE /api/v1/spaces/{space_id}", middleware.ApiAuth(middleware.ApiPermissionUseSpaces(HandleDeleteSpace)))
-	router.HandleFunc("GET /api/v1/spaces/{space_id}", middleware.ApiAuth(middleware.ApiPermissionUseSpaces(HandleGetSpace)))
-	router.HandleFunc("POST /api/v1/spaces/{space_id}/start", middleware.ApiAuth(middleware.ApiPermissionUseSpaces(HandleSpaceStart)))
-	router.HandleFunc("POST /api/v1/spaces/{space_id}/stop", middleware.ApiAuth(middleware.ApiPermissionUseSpaces(HandleSpaceStop)))
-	router.HandleFunc("POST /api/v1/spaces/{user_id}/stop-for-user", middleware.ApiAuth(middleware.ApiPermissionUseSpaces(HandleSpaceStopUsersSpaces)))
-	router.HandleFunc("POST /api/v1/spaces/{space_id}/transfer", middleware.ApiAuth(middleware.ApiPermissionTransferSpaces(HandleSpaceTransfer)))
-	router.HandleFunc("POST /api/v1/spaces/{space_id}/share", middleware.ApiAuth(middleware.ApiPermissionTransferSpaces(HandleSpaceAddShare)))
-	router.HandleFunc("DELETE /api/v1/spaces/{space_id}/share", middleware.ApiAuth(middleware.ApiPermissionTransferSpaces(HandleSpaceRemoveShare)))
+	router.HandleFunc("GET /api/spaces", middleware.ApiAuth(middleware.ApiPermissionUseSpaces(HandleGetSpaces)))
+	router.HandleFunc("POST /api/spaces", middleware.ApiAuth(middleware.ApiPermissionUseSpaces(HandleCreateSpace)))
+	router.HandleFunc("PUT /api/spaces/{space_id}", middleware.ApiAuth(middleware.ApiPermissionUseSpaces(HandleUpdateSpace)))
+	router.HandleFunc("DELETE /api/spaces/{space_id}", middleware.ApiAuth(middleware.ApiPermissionUseSpaces(HandleDeleteSpace)))
+	router.HandleFunc("GET /api/spaces/{space_id}", middleware.ApiAuth(middleware.ApiPermissionUseSpaces(HandleGetSpace)))
+	router.HandleFunc("POST /api/spaces/{space_id}/start", middleware.ApiAuth(middleware.ApiPermissionUseSpaces(HandleSpaceStart)))
+	router.HandleFunc("POST /api/spaces/{space_id}/stop", middleware.ApiAuth(middleware.ApiPermissionUseSpaces(HandleSpaceStop)))
+	router.HandleFunc("POST /api/spaces/{user_id}/stop-for-user", middleware.ApiAuth(middleware.ApiPermissionUseSpaces(HandleSpaceStopUsersSpaces)))
+	router.HandleFunc("POST /api/spaces/{space_id}/transfer", middleware.ApiAuth(middleware.ApiPermissionTransferSpaces(HandleSpaceTransfer)))
+	router.HandleFunc("POST /api/spaces/{space_id}/share", middleware.ApiAuth(middleware.ApiPermissionTransferSpaces(HandleSpaceAddShare)))
+	router.HandleFunc("DELETE /api/spaces/{space_id}/share", middleware.ApiAuth(middleware.ApiPermissionTransferSpaces(HandleSpaceRemoveShare)))
 
 	// Templates
-	router.HandleFunc("GET /api/v1/templates", middleware.ApiAuth(HandleGetTemplates))
-	router.HandleFunc("GET /api/v1/templates/{template_id}", middleware.ApiAuth(middleware.ApiPermissionManageTemplates(HandleGetTemplate)))
-	router.HandleFunc("POST /api/v1/templates", middleware.ApiAuth(middleware.ApiPermissionManageTemplates(HandleCreateTemplate)))
-	router.HandleFunc("PUT /api/v1/templates/{template_id}", middleware.ApiAuth(middleware.ApiPermissionManageTemplates(HandleUpdateTemplate)))
-	router.HandleFunc("DELETE /api/v1/templates/{template_id}", middleware.ApiAuth(middleware.ApiPermissionManageTemplates(HandleDeleteTemplate)))
+	router.HandleFunc("GET /api/templates", middleware.ApiAuth(HandleGetTemplates))
+	router.HandleFunc("GET /api/templates/{template_id}", middleware.ApiAuth(middleware.ApiPermissionManageTemplates(HandleGetTemplate)))
+	router.HandleFunc("POST /api/templates", middleware.ApiAuth(middleware.ApiPermissionManageTemplates(HandleCreateTemplate)))
+	router.HandleFunc("PUT /api/templates/{template_id}", middleware.ApiAuth(middleware.ApiPermissionManageTemplates(HandleUpdateTemplate)))
+	router.HandleFunc("DELETE /api/templates/{template_id}", middleware.ApiAuth(middleware.ApiPermissionManageTemplates(HandleDeleteTemplate)))
 
 	// Volumes
-	router.HandleFunc("GET /api/v1/volumes", middleware.ApiAuth(middleware.ApiPermissionManageVolumes(HandleGetVolumes)))
-	router.HandleFunc("POST /api/v1/volumes", middleware.ApiAuth(middleware.ApiPermissionManageVolumes(HandleCreateVolume)))
-	router.HandleFunc("PUT /api/v1/volumes/{volume_id}", middleware.ApiAuth(middleware.ApiPermissionManageVolumes(HandleUpdateVolume)))
-	router.HandleFunc("DELETE /api/v1/volumes/{volume_id}", middleware.ApiAuth(middleware.ApiPermissionManageVolumes(HandleDeleteVolume)))
-	router.HandleFunc("GET /api/v1/volumes/{volume_id}", middleware.ApiAuth(middleware.ApiPermissionManageVolumes(HandleGetVolume)))
-	router.HandleFunc("POST /api/v1/volumes/{volume_id}/start", middleware.ApiAuth(middleware.ApiPermissionManageVolumes(HandleVolumeStart)))
-	router.HandleFunc("POST /api/v1/volumes/{volume_id}/stop", middleware.ApiAuth(middleware.ApiPermissionManageVolumes(HandleVolumeStop)))
+	router.HandleFunc("GET /api/volumes", middleware.ApiAuth(middleware.ApiPermissionManageVolumes(HandleGetVolumes)))
+	router.HandleFunc("POST /api/volumes", middleware.ApiAuth(middleware.ApiPermissionManageVolumes(HandleCreateVolume)))
+	router.HandleFunc("PUT /api/volumes/{volume_id}", middleware.ApiAuth(middleware.ApiPermissionManageVolumes(HandleUpdateVolume)))
+	router.HandleFunc("DELETE /api/volumes/{volume_id}", middleware.ApiAuth(middleware.ApiPermissionManageVolumes(HandleDeleteVolume)))
+	router.HandleFunc("GET /api/volumes/{volume_id}", middleware.ApiAuth(middleware.ApiPermissionManageVolumes(HandleGetVolume)))
+	router.HandleFunc("POST /api/volumes/{volume_id}/start", middleware.ApiAuth(middleware.ApiPermissionManageVolumes(HandleVolumeStart)))
+	router.HandleFunc("POST /api/volumes/{volume_id}/stop", middleware.ApiAuth(middleware.ApiPermissionManageVolumes(HandleVolumeStop)))
 
 	// Template Variables
-	router.HandleFunc("GET /api/v1/templatevars", middleware.ApiAuth(middleware.ApiPermissionManageVariables(HandleGetTemplateVars)))
-	router.HandleFunc("POST /api/v1/templatevars", middleware.ApiAuth(middleware.ApiPermissionManageVariables(HandleCreateTemplateVar)))
-	router.HandleFunc("PUT /api/v1/templatevars/{templatevar_id}", middleware.ApiAuth(middleware.ApiPermissionManageVariables(HandleUpdateTemplateVar)))
-	router.HandleFunc("DELETE /api/v1/templatevars/{templatevar_id}", middleware.ApiAuth(middleware.ApiPermissionManageVariables(HandleDeleteTemplateVar)))
-	router.HandleFunc("GET /api/v1/templatevars/{templatevar_id}", middleware.ApiAuth(middleware.ApiPermissionManageVariables(HandleGetTemplateVar)))
+	router.HandleFunc("GET /api/templatevars", middleware.ApiAuth(middleware.ApiPermissionManageVariables(HandleGetTemplateVars)))
+	router.HandleFunc("POST /api/templatevars", middleware.ApiAuth(middleware.ApiPermissionManageVariables(HandleCreateTemplateVar)))
+	router.HandleFunc("PUT /api/templatevars/{templatevar_id}", middleware.ApiAuth(middleware.ApiPermissionManageVariables(HandleUpdateTemplateVar)))
+	router.HandleFunc("DELETE /api/templatevars/{templatevar_id}", middleware.ApiAuth(middleware.ApiPermissionManageVariables(HandleDeleteTemplateVar)))
+	router.HandleFunc("GET /api/templatevars/{templatevar_id}", middleware.ApiAuth(middleware.ApiPermissionManageVariables(HandleGetTemplateVar)))
 
 	// Tunnels
-	router.HandleFunc("GET /api/v1/tunnels", middleware.ApiAuth(middleware.ApiPermissionUseTunnels(HandleGetTunnels)))
-	router.HandleFunc("GET /api/v1/tunnels/domain", middleware.ApiAuth(middleware.ApiPermissionUseTunnels(HandleGetTunnelDomain)))
-	router.HandleFunc("DELETE /api/v1/tunnels/{tunnel_name}", middleware.ApiAuth(middleware.ApiPermissionUseTunnels(HandleDeleteTunnel)))
+	router.HandleFunc("GET /api/tunnels", middleware.ApiAuth(middleware.ApiPermissionUseTunnels(HandleGetTunnels)))
+	router.HandleFunc("GET /api/tunnels/domain", middleware.ApiAuth(middleware.ApiPermissionUseTunnels(HandleGetTunnelDomain)))
+	router.HandleFunc("DELETE /api/tunnels/{tunnel_name}", middleware.ApiAuth(middleware.ApiPermissionUseTunnels(HandleDeleteTunnel)))
 
 	// Audit Logs
-	router.HandleFunc("GET /api/v1/audit-logs", middleware.ApiAuth(middleware.ApiPermissionViewAuditLogs(HandleGetAuditLogs)))
+	router.HandleFunc("GET /api/audit-logs", middleware.ApiAuth(middleware.ApiPermissionViewAuditLogs(HandleGetAuditLogs)))
 
 	// Unauthenticated routes
-	router.HandleFunc("POST /api/v1/auth", HandleAuthorization)
-	router.HandleFunc("POST /api/v1/auth/web", HandleAuthorization)
-	router.HandleFunc("GET /api/v1/auth/using-totp", HandleUsingTotp)
+	router.HandleFunc("POST /api/auth", HandleAuthorization)
+	router.HandleFunc("POST /api/auth/web", HandleAuthorization)
+	router.HandleFunc("GET /api/auth/using-totp", HandleUsingTotp)
 
 	// Additional endpoints exposed by origin servers
 	if server_info.IsOrigin {
 		// Remote server authenticated routes
-		router.HandleFunc("GET /api/v1/leaf-server", middleware.LeafServerAuth(origin_leaf.OriginListenAndServe))
+		router.HandleFunc("GET /api/leaf-server", middleware.LeafServerAuth(origin_leaf.OriginListenAndServe))
 	}
 }

--- a/api/apiv1/spec/knot-openapi.yaml
+++ b/api/apiv1/spec/knot-openapi.yaml
@@ -33,7 +33,7 @@ tags:
       These operations are for working with users.
 paths:
 
-  /api/v1/auth/using-totp:
+  /api/auth/using-totp:
     get:
       tags:
         - Authorization
@@ -52,7 +52,7 @@ paths:
                     type: boolean
                     description: True if TOTP is enabled.
 
-  /api/v1/audit-logs:
+  /api/audit-logs:
     get:
       tags:
       - Audit Logs
@@ -89,7 +89,7 @@ paths:
         '500':
           $ref: '#/components/responses/internal-server-error'
 
-  /api/v1/tunnels/{tunnel_id}:
+  /api/tunnels/{tunnel_id}:
     delete:
       tags:
         - Tunnels
@@ -115,7 +115,7 @@ paths:
       security:
         - BearerAuth: []
 
-  /api/v1/tunnels:
+  /api/tunnels:
     get:
       tags:
         - Tunnels
@@ -136,7 +136,7 @@ paths:
         '500':
           $ref: '#/components/responses/internal-server-error'
 
-  /api/v1/tunnels/domain:
+  /api/tunnels/domain:
     get:
       tags:
         - Tunnels
@@ -155,7 +155,7 @@ paths:
         '500':
           $ref: '#/components/responses/internal-server-error'
 
-  /api/v1/users:
+  /api/users:
     post:
       tags:
         - Users
@@ -246,7 +246,7 @@ paths:
       security:
         - BearerAuth: []
 
-  /api/v1/users/{user_id}:
+  /api/users/{user_id}:
     get:
       tags:
         - Users
@@ -340,7 +340,7 @@ paths:
       security:
         - BearerAuth: []
 
-  /api/v1/users/{user_id}/quota:
+  /api/users/{user_id}/quota:
     get:
       tags:
         - Users
@@ -372,7 +372,7 @@ paths:
       security:
         - BearerAuth: []
 
-  /api/v1/users/whoami:
+  /api/users/whoami:
     get:
       tags:
         - Users
@@ -392,7 +392,7 @@ paths:
       security:
         - BearerAuth: []
 
-  /api/v1/permissions:
+  /api/permissions:
     get:
       summary: Get Permissions
       description: Retrieve all permissions.
@@ -413,7 +413,7 @@ paths:
       security:
         - BearerAuth: []
 
-  /api/v1/groups:
+  /api/groups:
     get:
       summary: Get Groups
       description: Retrieve all groups.
@@ -462,7 +462,7 @@ paths:
       security:
         - BearerAuth: []
 
-  /api/v1/groups/{group_id}:
+  /api/groups/{group_id}:
     put:
       summary: Update a Group
       description: Update a group.
@@ -559,7 +559,7 @@ paths:
       security:
         - BearerAuth: []
 
-  /api/v1/roles:
+  /api/roles:
     get:
       tags:
         - Roles
@@ -615,7 +615,7 @@ paths:
       security:
         - BearerAuth: []
 
-  /api/v1/roles/{role_id}:
+  /api/roles/{role_id}:
     put:
       summary: Update a Role
       description: Update a role.
@@ -712,7 +712,7 @@ paths:
       security:
         - BearerAuth: []
 
-  /api/v1/sessions:
+  /api/sessions:
     get:
       tags:
         - Users
@@ -735,7 +735,7 @@ paths:
       security:
         - BearerAuth: []
 
-  /api/v1/sessions/{session_id}:
+  /api/sessions/{session_id}:
     delete:
       tags:
         - Users
@@ -761,7 +761,7 @@ paths:
       security:
         - BearerAuth: []
 
-  /api/v1/auth:
+  /api/auth:
     post:
       tags:
         - Authorization
@@ -791,7 +791,7 @@ paths:
         '500':
           $ref: '#/components/responses/internal-server-error'
 
-  /api/v1/auth/web:
+  /api/auth/web:
     post:
       tags:
         - Authorization
@@ -821,7 +821,7 @@ paths:
         '500':
           $ref: '#/components/responses/internal-server-error'
 
-  /api/v1/auth/logout:
+  /api/auth/logout:
     post:
       tags:
         - Authorization
@@ -841,7 +841,7 @@ paths:
         '500':
           $ref: '#/components/responses/internal-server-error'
 
-  /api/v1/tokens:
+  /api/tokens:
     get:
       summary: Get Tokens
       description: Get all tokens for the authenticated user.
@@ -888,7 +888,7 @@ paths:
       security:
         - BearerAuth: []
 
-  /api/v1/tokens/{token_id}:
+  /api/tokens/{token_id}:
     delete:
       summary: Delete Token
       description: Delete a specific token for the authenticated user.
@@ -914,7 +914,7 @@ paths:
       security:
         - BearerAuth: []
 
-  /api/v1/spaces:
+  /api/spaces:
     get:
       summary: Get Spaces
       description: Retrieve all spaces for a user.
@@ -983,7 +983,7 @@ paths:
       security:
         - BearerAuth: []
 
-  /api/v1/spaces/{space_id}:
+  /api/spaces/{space_id}:
     delete:
       summary: Delete a Space
       description: Delete a space for the authenticated user.
@@ -1078,7 +1078,7 @@ paths:
       security:
         - BearerAuth: []
 
-  /api/v1/spaces/{space_id}/transfer:
+  /api/spaces/{space_id}/transfer:
     post:
       summary: Transfer a Space
       description: Transfer a space to another user.
@@ -1120,7 +1120,7 @@ paths:
       security:
         - BearerAuth: []
 
-  /api/v1/spaces/{space_id}/share:
+  /api/spaces/{space_id}/share:
     post:
       summary: Share a Space
       description: Share a space with another user.
@@ -1195,7 +1195,7 @@ paths:
       security:
         - BearerAuth: []
 
-  /api/v1/spaces/{space_id}/start:
+  /api/spaces/{space_id}/start:
     post:
       summary: Start a Space
       description: Deploy a space to the Nomad cluster creating any required volumes.
@@ -1230,7 +1230,7 @@ paths:
       security:
         - BearerAuth: []
 
-  /api/v1/spaces/{space_id}/stop:
+  /api/spaces/{space_id}/stop:
     post:
       summary: Stop a Space
       description: Stop the space from running, volumes are left intact.
@@ -1259,7 +1259,7 @@ paths:
       security:
         - BearerAuth: []
 
-  /api/v1/spaces/{user_id}/stop-for-user:
+  /api/spaces/{user_id}/stop-for-user:
     post:
       summary: Stop Users Spaces
       description: Stop all the spaces belonging to a user.
@@ -1285,7 +1285,7 @@ paths:
       security:
         - BearerAuth: []
 
-  /api/v1/templates:
+  /api/templates:
     get:
       summary: Get Templates
       description: Retrieve all templates.
@@ -1355,7 +1355,7 @@ paths:
       security:
         - BearerAuth: []
 
-  /api/v1/templates/{template_id}:
+  /api/templates/{template_id}:
     put:
       summary: Update a Template
       description: Update a template.
@@ -1455,7 +1455,7 @@ paths:
       security:
         - BearerAuth: []
 
-  /api/v1/templatevars:
+  /api/templatevars:
     get:
       summary: Get Template Variables
       description: Retrieve all template variables.
@@ -1514,7 +1514,7 @@ paths:
       security:
         - BearerAuth: []
 
-  /api/v1/templatevars/{templatevar_id}:
+  /api/templatevars/{templatevar_id}:
     put:
       summary: Update a Template Variable
       description: Update a template variable.
@@ -1600,7 +1600,7 @@ paths:
       security:
         - BearerAuth: []
 
-  /api/v1/volumes:
+  /api/volumes:
     get:
       summary: Get Volumes
       description: Retrieve all volumes.
@@ -1669,7 +1669,7 @@ paths:
       security:
         - BearerAuth: []
 
-  /api/v1/volumes/{volume_id}:
+  /api/volumes/{volume_id}:
     put:
       summary: Update a Volume
       description: Update a volume.
@@ -1760,7 +1760,7 @@ paths:
       security:
         - BearerAuth: []
 
-  /api/v1/volumes/{volume_id}/start:
+  /api/volumes/{volume_id}/start:
     post:
       summary: Start a Volume
       description: Start a specified volume.
@@ -1802,7 +1802,7 @@ paths:
       security:
         - BearerAuth: []
 
-  /api/v1/volumes/{volume_id}/stop:
+  /api/volumes/{volume_id}/stop:
     post:
       summary: Stop a Volume
       description: Stop a specified volume.
@@ -1861,7 +1861,7 @@ paths:
       security:
         - BearerAuth: []
 
-  /api/v1/lookup/{service}:
+  /api/lookup/{service}:
     get:
       tags:
         - Core
@@ -1886,7 +1886,7 @@ paths:
       security:
         - BearerAuth: []
 
-  /api/v1/ping:
+  /api/ping:
     get:
       tags:
         - Core

--- a/apiclient/auditlog.go
+++ b/apiclient/auditlog.go
@@ -23,7 +23,7 @@ type AuditLogs struct {
 func (c *ApiClient) GetAuditLogs(start int, maxItems int) (*AuditLogs, int, error) {
 	response := &AuditLogs{}
 
-	code, err := c.httpClient.Get(fmt.Sprintf("/api/v1/audit-logs?start=%d&max-items=%d", start, maxItems), response)
+	code, err := c.httpClient.Get(fmt.Sprintf("/api/audit-logs?start=%d&max-items=%d", start, maxItems), response)
 	if err != nil {
 		return nil, code, err
 	}

--- a/apiclient/auth.go
+++ b/apiclient/auth.go
@@ -28,7 +28,7 @@ func (c *ApiClient) Login(email string, password string, totpCode string) (strin
 	}
 	response := AuthLoginResponse{}
 
-	code, err := c.httpClient.Post("/api/v1/auth", &request, &response, 200)
+	code, err := c.httpClient.Post("/api/auth", &request, &response, 200)
 	if err != nil {
 		return "", "", code, err
 	}
@@ -39,7 +39,7 @@ func (c *ApiClient) Login(email string, password string, totpCode string) (strin
 func (c *ApiClient) Logout() error {
 	response := AuthLogoutResponse{}
 
-	_, err := c.httpClient.Post("/api/v1/auth/logout", nil, &response, 200)
+	_, err := c.httpClient.Post("/api/auth/logout", nil, &response, 200)
 	if err != nil {
 		return err
 	}
@@ -51,7 +51,7 @@ func (c *ApiClient) Logout() error {
 func (c *ApiClient) LoginUserToken(userId string, token string) error {
 	response := AuthLoginResponse{}
 
-	_, err := c.httpClient.Post("/api/v1/auth/user", nil, &response, 200)
+	_, err := c.httpClient.Post("/api/auth/user", nil, &response, 200)
 	if err != nil {
 		return err
 	}
@@ -62,7 +62,7 @@ func (c *ApiClient) LoginUserToken(userId string, token string) error {
 func (c *ApiClient) UsingTOTP() (bool, int, error) {
 	response := UsingTOTPResponse{}
 
-	code, err := c.httpClient.Get("/api/v1/auth/using-totp", &response)
+	code, err := c.httpClient.Get("/api/auth/using-totp", &response)
 	if err != nil {
 		return false, code, err
 	}

--- a/apiclient/groups.go
+++ b/apiclient/groups.go
@@ -30,7 +30,7 @@ type GroupResponse struct {
 func (c *ApiClient) GetGroups() (*GroupInfoList, int, error) {
 	response := &GroupInfoList{}
 
-	code, err := c.httpClient.Get("/api/v1/groups", response)
+	code, err := c.httpClient.Get("/api/groups", response)
 	if err != nil {
 		return nil, code, err
 	}
@@ -47,7 +47,7 @@ func (c *ApiClient) UpdateGroup(groupId string, groupName string, maxSpaces uint
 		MaxTunnels:   maxTunnels,
 	}
 
-	code, err := c.httpClient.Put("/api/v1/groups/"+groupId, request, nil, 200)
+	code, err := c.httpClient.Put("/api/groups/"+groupId, request, nil, 200)
 	if err != nil {
 		return code, err
 	}
@@ -66,7 +66,7 @@ func (c *ApiClient) CreateGroup(groupName string, maxSpaces uint32, computeUnits
 
 	response := &GroupResponse{}
 
-	code, err := c.httpClient.Post("/api/v1/groups", request, response, 201)
+	code, err := c.httpClient.Post("/api/groups", request, response, 201)
 	if err != nil {
 		return "", code, err
 	}
@@ -75,13 +75,13 @@ func (c *ApiClient) CreateGroup(groupName string, maxSpaces uint32, computeUnits
 }
 
 func (c *ApiClient) DeleteGroup(groupId string) (int, error) {
-	return c.httpClient.Delete("/api/v1/groups/"+groupId, nil, nil, 200)
+	return c.httpClient.Delete("/api/groups/"+groupId, nil, nil, 200)
 }
 
 func (c *ApiClient) GetGroup(groupId string) (*GroupInfo, int, error) {
 	response := &GroupInfo{}
 
-	code, err := c.httpClient.Get("/api/v1/groups/"+groupId, response)
+	code, err := c.httpClient.Get("/api/groups/"+groupId, response)
 	if err != nil {
 		return nil, code, err
 	}

--- a/apiclient/permissions.go
+++ b/apiclient/permissions.go
@@ -13,7 +13,7 @@ type PermissionInfoList struct {
 func (c *ApiClient) GetPermissions() (*PermissionInfoList, int, error) {
 	response := &PermissionInfoList{}
 
-	code, err := c.httpClient.Get("/api/v1/permissions", response)
+	code, err := c.httpClient.Get("/api/permissions", response)
 	if err != nil {
 		return nil, code, err
 	}

--- a/apiclient/ping.go
+++ b/apiclient/ping.go
@@ -9,7 +9,7 @@ type PingResponse struct {
 
 func (c *ApiClient) Ping() (string, error) {
 	ping := PingResponse{}
-	statusCode, err := c.httpClient.Get("/api/v1/ping", &ping)
+	statusCode, err := c.httpClient.Get("/api/ping", &ping)
 	if statusCode != 200 {
 		return "", errors.New("invalid status code")
 	}

--- a/apiclient/roles.go
+++ b/apiclient/roles.go
@@ -29,7 +29,7 @@ type RoleResponse struct {
 func (c *ApiClient) GetRoles() (*RoleInfoList, int, error) {
 	response := &RoleInfoList{}
 
-	code, err := c.httpClient.Get("/api/v1/roles", response)
+	code, err := c.httpClient.Get("/api/roles", response)
 	if err != nil {
 		return nil, code, err
 	}
@@ -43,7 +43,7 @@ func (c *ApiClient) UpdateRole(roleId string, roleName string, permissions []uin
 		Permissions: permissions,
 	}
 
-	code, err := c.httpClient.Put("/api/v1/roles/"+roleId, request, nil, 200)
+	code, err := c.httpClient.Put("/api/roles/"+roleId, request, nil, 200)
 	if err != nil {
 		return code, err
 	}
@@ -59,7 +59,7 @@ func (c *ApiClient) CreateRole(roleName string, permissions []uint16) (string, i
 
 	response := &RoleResponse{}
 
-	code, err := c.httpClient.Post("/api/v1/roles", request, response, 201)
+	code, err := c.httpClient.Post("/api/roles", request, response, 201)
 	if err != nil {
 		return "", code, err
 	}
@@ -68,13 +68,13 @@ func (c *ApiClient) CreateRole(roleName string, permissions []uint16) (string, i
 }
 
 func (c *ApiClient) DeleteRole(roleId string) (int, error) {
-	return c.httpClient.Delete("/api/v1/roles/"+roleId, nil, nil, 200)
+	return c.httpClient.Delete("/api/roles/"+roleId, nil, nil, 200)
 }
 
 func (c *ApiClient) GetRole(roleId string) (*RoleDetails, int, error) {
 	response := &RoleDetails{}
 
-	code, err := c.httpClient.Get("/api/v1/roles/"+roleId, response)
+	code, err := c.httpClient.Get("/api/roles/"+roleId, response)
 	if err != nil {
 		return nil, code, err
 	}

--- a/apiclient/spaces.go
+++ b/apiclient/spaces.go
@@ -75,7 +75,7 @@ type SpaceDefinition struct {
 func (c *ApiClient) GetSpaces(userId string) (*SpaceInfoList, int, error) {
 	response := &SpaceInfoList{}
 
-	code, err := c.httpClient.Get("/api/v1/spaces?user_id="+userId, &response)
+	code, err := c.httpClient.Get("/api/spaces?user_id="+userId, &response)
 	if err != nil {
 		return nil, code, err
 	}
@@ -86,7 +86,7 @@ func (c *ApiClient) GetSpaces(userId string) (*SpaceInfoList, int, error) {
 func (c *ApiClient) GetSpace(spaceId string) (*model.Space, int, error) {
 	response := &SpaceDefinition{}
 
-	code, err := c.httpClient.Get("/api/v1/spaces/"+spaceId, &response)
+	code, err := c.httpClient.Get("/api/spaces/"+spaceId, &response)
 	if err != nil {
 		return nil, code, err
 	}
@@ -123,7 +123,7 @@ func (c *ApiClient) UpdateSpace(space *model.Space) (int, error) {
 		Location:   space.Location,
 	}
 
-	code, err := c.httpClient.Put("/api/v1/spaces/"+space.Id, request, nil, 200)
+	code, err := c.httpClient.Put("/api/spaces/"+space.Id, request, nil, 200)
 	if err != nil {
 		return code, err
 	}
@@ -143,7 +143,7 @@ func (c *ApiClient) CreateSpace(space *model.Space) (int, error) {
 
 	response := &CreateSpaceResponse{}
 
-	code, err := c.httpClient.Post("/api/v1/spaces", request, response, 201)
+	code, err := c.httpClient.Post("/api/spaces", request, response, 201)
 	if err != nil {
 		return code, err
 	}
@@ -155,15 +155,15 @@ func (c *ApiClient) CreateSpace(space *model.Space) (int, error) {
 }
 
 func (c *ApiClient) DeleteSpace(spaceId string) (int, error) {
-	return c.httpClient.Delete("/api/v1/spaces/"+spaceId, nil, nil, 200)
+	return c.httpClient.Delete("/api/spaces/"+spaceId, nil, nil, 200)
 }
 
 func (c *ApiClient) StartSpace(spaceId string) (int, error) {
-	return c.httpClient.Post("/api/v1/spaces/"+spaceId+"/start", nil, nil, 200)
+	return c.httpClient.Post("/api/spaces/"+spaceId+"/start", nil, nil, 200)
 }
 
 func (c *ApiClient) StopSpace(spaceId string) (int, error) {
-	return c.httpClient.Post("/api/v1/spaces/"+spaceId+"/stop", nil, nil, 200)
+	return c.httpClient.Post("/api/spaces/"+spaceId+"/stop", nil, nil, 200)
 }
 
 func (c *ApiClient) TransferSpace(spaceId string, userId string) (int, error) {
@@ -171,5 +171,5 @@ func (c *ApiClient) TransferSpace(spaceId string, userId string) (int, error) {
 		UserId: userId,
 	}
 
-	return c.httpClient.Post("/api/v1/spaces/"+spaceId+"/transfer", request, nil, 200)
+	return c.httpClient.Post("/api/spaces/"+spaceId+"/transfer", request, nil, 200)
 }

--- a/apiclient/templates.go
+++ b/apiclient/templates.go
@@ -93,7 +93,7 @@ type TemplateDetails struct {
 func (c *ApiClient) GetTemplates() (*TemplateList, int, error) {
 	response := &TemplateList{}
 
-	code, err := c.httpClient.Get("/api/v1/templates", response)
+	code, err := c.httpClient.Get("/api/templates", response)
 	if err != nil {
 		return nil, code, err
 	}
@@ -125,7 +125,7 @@ func (c *ApiClient) UpdateTemplate(templateId string, name string, job string, d
 		request.Schedule = *schedule
 	}
 
-	return c.httpClient.Put("/api/v1/templates/"+templateId, &request, nil, 200)
+	return c.httpClient.Put("/api/templates/"+templateId, &request, nil, 200)
 }
 
 func (c *ApiClient) CreateTemplate(name string, job string, description string, volumes string, groups []string, localContainer bool, IsManual bool, withTerminal bool, withVSCodeTunnel bool, withCodeServer bool, withSSH bool, computeUnits uint32, storageUnits uint32, scheduleEnabled bool, schedule *[]TemplateDetailsDay, locations []string) (string, int, error) {
@@ -156,7 +156,7 @@ func (c *ApiClient) CreateTemplate(name string, job string, description string, 
 
 	response := &TemplateCreateResponse{}
 
-	code, err := c.httpClient.Post("/api/v1/templates", &request, &response, 201)
+	code, err := c.httpClient.Post("/api/templates", &request, &response, 201)
 	if err != nil {
 		return "", code, err
 	}
@@ -165,13 +165,13 @@ func (c *ApiClient) CreateTemplate(name string, job string, description string, 
 }
 
 func (c *ApiClient) DeleteTemplate(templateId string) (int, error) {
-	return c.httpClient.Delete("/api/v1/templates/"+templateId, nil, nil, 200)
+	return c.httpClient.Delete("/api/templates/"+templateId, nil, nil, 200)
 }
 
 func (c *ApiClient) GetTemplate(templateId string) (*TemplateDetails, int, error) {
 	response := &TemplateDetails{}
 
-	code, err := c.httpClient.Get("/api/v1/templates/"+templateId, response)
+	code, err := c.httpClient.Get("/api/templates/"+templateId, response)
 	if err != nil {
 		return nil, code, err
 	}

--- a/apiclient/templatevars.go
+++ b/apiclient/templatevars.go
@@ -31,7 +31,7 @@ type TemplateVarCreateResponse struct {
 func (c *ApiClient) GetTemplateVars() (*TemplateVarList, int, error) {
 	response := &TemplateVarList{}
 
-	code, err := c.httpClient.Get("/api/v1/templatevars", response)
+	code, err := c.httpClient.Get("/api/templatevars", response)
 	if err != nil {
 		return nil, code, err
 	}
@@ -49,7 +49,7 @@ func (c *ApiClient) UpdateTemplateVar(templateVarId string, name string, locatio
 		Restricted: restricted,
 	}
 
-	return c.httpClient.Put("/api/v1/templatevars/"+templateVarId, request, nil, 200)
+	return c.httpClient.Put("/api/templatevars/"+templateVarId, request, nil, 200)
 }
 
 func (c *ApiClient) CreateTemplateVar(name string, location string, local bool, value string, protected bool, restricted bool) (string, int, error) {
@@ -64,7 +64,7 @@ func (c *ApiClient) CreateTemplateVar(name string, location string, local bool, 
 
 	response := &TemplateVarCreateResponse{}
 
-	code, err := c.httpClient.Post("/api/v1/templatevars", request, response, 201)
+	code, err := c.httpClient.Post("/api/templatevars", request, response, 201)
 	if err != nil {
 		return "", code, err
 	}
@@ -73,13 +73,13 @@ func (c *ApiClient) CreateTemplateVar(name string, location string, local bool, 
 }
 
 func (c *ApiClient) DeleteTemplateVar(templateVarId string) (int, error) {
-	return c.httpClient.Delete("/api/v1/templatevars/"+templateVarId, nil, nil, 200)
+	return c.httpClient.Delete("/api/templatevars/"+templateVarId, nil, nil, 200)
 }
 
 func (c *ApiClient) GetTemplateVar(templateVarId string) (*TemplateVarValue, int, error) {
 	response := &TemplateVarValue{}
 
-	code, err := c.httpClient.Get("/api/v1/templatevars/"+templateVarId, response)
+	code, err := c.httpClient.Get("/api/templatevars/"+templateVarId, response)
 	if err != nil {
 		return nil, code, err
 	}

--- a/apiclient/tokens.go
+++ b/apiclient/tokens.go
@@ -20,7 +20,7 @@ type CreateTokenResponse struct {
 func (c *ApiClient) GetTokens() (*[]TokenInfo, int, error) {
 	response := &[]TokenInfo{}
 
-	code, err := c.httpClient.Get("/api/v1/tokens", response)
+	code, err := c.httpClient.Get("/api/tokens", response)
 	if err != nil {
 		return nil, code, err
 	}
@@ -29,7 +29,7 @@ func (c *ApiClient) GetTokens() (*[]TokenInfo, int, error) {
 }
 
 func (c *ApiClient) DeleteToken(tokenId string) (int, error) {
-	return c.httpClient.Delete("/api/v1/tokens/"+tokenId, nil, nil, 200)
+	return c.httpClient.Delete("/api/tokens/"+tokenId, nil, nil, 200)
 }
 
 func (c *ApiClient) CreateToken(name string) (string, int, error) {
@@ -39,7 +39,7 @@ func (c *ApiClient) CreateToken(name string) (string, int, error) {
 
 	response := &CreateTokenResponse{}
 
-	code, err := c.httpClient.Post("/api/v1/tokens", request, response, 201)
+	code, err := c.httpClient.Post("/api/tokens", request, response, 201)
 	if err != nil {
 		return "", code, err
 	}

--- a/apiclient/tunnels.go
+++ b/apiclient/tunnels.go
@@ -8,7 +8,7 @@ type TunnelInfo struct {
 func (c *ApiClient) GetTunnels() ([]TunnelInfo, int, error) {
 	response := []TunnelInfo{}
 
-	code, err := c.httpClient.Get("/api/v1/tunnels", &response)
+	code, err := c.httpClient.Get("/api/tunnels", &response)
 	if err != nil {
 		return nil, code, err
 	}
@@ -19,7 +19,7 @@ func (c *ApiClient) GetTunnels() ([]TunnelInfo, int, error) {
 func (c *ApiClient) GetTunnelDomain() (string, int, error) {
 	response := ""
 
-	code, err := c.httpClient.Get("/api/v1/tunnels/domain", &response)
+	code, err := c.httpClient.Get("/api/tunnels/domain", &response)
 	if err != nil {
 		return "", code, err
 	}

--- a/apiclient/users.go
+++ b/apiclient/users.go
@@ -96,7 +96,7 @@ type UserQuota struct {
 func (c *ApiClient) CreateUser(request *CreateUserRequest) (string, int, error) {
 	response := CreateUserResponse{}
 
-	code, err := c.httpClient.Post("/api/v1/users", request, &response, 201)
+	code, err := c.httpClient.Post("/api/users", request, &response, 201)
 	if err != nil {
 		return "", code, err
 	}
@@ -107,7 +107,7 @@ func (c *ApiClient) CreateUser(request *CreateUserRequest) (string, int, error) 
 func (c *ApiClient) GetUser(userId string) (*model.User, error) {
 	response := UserResponse{}
 
-	code, err := c.httpClient.Get("/api/v1/users/"+userId, &response)
+	code, err := c.httpClient.Get("/api/users/"+userId, &response)
 	if err != nil {
 		if code == 404 {
 			return nil, errors.New("user not found")
@@ -144,7 +144,7 @@ func (c *ApiClient) GetUser(userId string) (*model.User, error) {
 func (c *ApiClient) WhoAmI() (*model.User, error) {
 	response := UserResponse{}
 
-	_, err := c.httpClient.Get("/api/v1/users/whoami", &response)
+	_, err := c.httpClient.Get("/api/users/whoami", &response)
 	if err != nil {
 		return nil, err
 	}
@@ -179,7 +179,7 @@ func (c *ApiClient) GetUsers(state string, location string) (*UserInfoList, erro
 	stateEncoded := url.QueryEscape(state)
 	locationEncoded := url.QueryEscape(location)
 
-	_, err := c.httpClient.Get("/api/v1/users?state="+stateEncoded+"&location="+locationEncoded, &response)
+	_, err := c.httpClient.Get("/api/users?state="+stateEncoded+"&location="+locationEncoded, &response)
 	if err != nil {
 		return nil, err
 	}
@@ -207,7 +207,7 @@ func (c *ApiClient) UpdateUser(user *model.User) error {
 		TOTPSecret:      user.TOTPSecret,
 	}
 
-	_, err := c.httpClient.Put("/api/v1/users/"+user.Id, &request, nil, 200)
+	_, err := c.httpClient.Put("/api/users/"+user.Id, &request, nil, 200)
 	if err != nil {
 		return err
 	}
@@ -216,14 +216,14 @@ func (c *ApiClient) UpdateUser(user *model.User) error {
 }
 
 func (c *ApiClient) DeleteUser(userId string) error {
-	_, err := c.httpClient.Delete("/api/v1/users/"+userId, nil, nil, 200)
+	_, err := c.httpClient.Delete("/api/users/"+userId, nil, nil, 200)
 	return err
 }
 
 func (c *ApiClient) GetUserQuota(userId string) (*UserQuota, error) {
 	response := UserQuota{}
 
-	code, err := c.httpClient.Get("/api/v1/users/"+userId+"/quota", &response)
+	code, err := c.httpClient.Get("/api/users/"+userId+"/quota", &response)
 	if err != nil {
 		if code == 404 {
 			return nil, errors.New("user not found")

--- a/apiclient/volumes.go
+++ b/apiclient/volumes.go
@@ -62,7 +62,7 @@ type StartVolumeResponse struct {
 func (c *ApiClient) GetVolumes() (*VolumeInfoList, int, error) {
 	response := &VolumeInfoList{}
 
-	code, err := c.httpClient.Get("/api/v1/volumes", response)
+	code, err := c.httpClient.Get("/api/volumes", response)
 	if err != nil {
 		return nil, code, err
 	}
@@ -79,7 +79,7 @@ func (c *ApiClient) CreateVolume(name string, definition string, localContainer 
 
 	response := &VolumeCreateResponse{}
 
-	code, err := c.httpClient.Post("/api/v1/volumes", request, response, 201)
+	code, err := c.httpClient.Post("/api/volumes", request, response, 201)
 	if err != nil {
 		return nil, code, err
 	}
@@ -93,17 +93,17 @@ func (c *ApiClient) UpdateVolume(volumeId string, name string, definition string
 		Definition: definition,
 	}
 
-	return c.httpClient.Put("/api/v1/volumes/"+volumeId, request, nil, 200)
+	return c.httpClient.Put("/api/volumes/"+volumeId, request, nil, 200)
 }
 
 func (c *ApiClient) DeleteVolume(volumeId string) (int, error) {
-	return c.httpClient.Delete("/api/v1/volumes/"+volumeId, nil, nil, 200)
+	return c.httpClient.Delete("/api/volumes/"+volumeId, nil, nil, 200)
 }
 
 func (c *ApiClient) GetVolume(volumeId string) (*VolumeDefinition, int, error) {
 	response := VolumeDefinition{}
 
-	code, err := c.httpClient.Get("/api/v1/volumes/"+volumeId, &response)
+	code, err := c.httpClient.Get("/api/volumes/"+volumeId, &response)
 	if err != nil {
 		return nil, code, err
 	}
@@ -132,7 +132,7 @@ func (c *ApiClient) GetVolumeObject(volumeId string) (*model.Volume, int, error)
 func (c *ApiClient) StartVolume(volumeId string) (*StartVolumeResponse, int, error) {
 	response := StartVolumeResponse{}
 
-	code, err := c.httpClient.Post("/api/v1/volumes/"+volumeId+"/start", nil, &response, 200)
+	code, err := c.httpClient.Post("/api/volumes/"+volumeId+"/start", nil, &response, 200)
 	if err != nil {
 		return nil, code, err
 	}
@@ -141,5 +141,5 @@ func (c *ApiClient) StartVolume(volumeId string) (*StartVolumeResponse, int, err
 }
 
 func (c *ApiClient) StopVolume(volumeId string) (int, error) {
-	return c.httpClient.Post("/api/v1/volumes/"+volumeId+"/stop", nil, nil, 200)
+	return c.httpClient.Post("/api/volumes/"+volumeId+"/stop", nil, nil, 200)
 }

--- a/internal/origin_leaf/leaf_server.go
+++ b/internal/origin_leaf/leaf_server.go
@@ -52,7 +52,7 @@ func LeafConnectAndServe(server string) {
 			} else {
 				wsUrl = "wss://" + wsUrl
 			}
-			wsUrl += "/api/v1/leaf-server"
+			wsUrl += "/api/leaf-server"
 
 			log.Debug().Msgf("leaf: connecting to %s", wsUrl)
 

--- a/middleware/authmiddleware.go
+++ b/middleware/authmiddleware.go
@@ -135,6 +135,13 @@ func ApiAuth(next http.HandlerFunc) http.HandlerFunc {
 
 			// Add the user to the context
 			ctx = context.WithValue(ctx, "user", user)
+
+			// Get the API version
+			apiVersion := r.Header.Get("X-Knot-Api-Version")
+			if apiVersion == "" {
+				apiVersion = "2025-03-10"
+			}
+			ctx = context.WithValue(ctx, "api_version", apiVersion)
 		}
 
 		// If authenticated, continue

--- a/web/src/js/pages/apiTokensComponent.js
+++ b/web/src/js/pages/apiTokensComponent.js
@@ -29,7 +29,7 @@ window.apiTokensComponent = function() {
     },
 
     async getTokens() {
-      const response = await fetch('/api/v1/tokens', {
+      const response = await fetch('/api/tokens', {
         headers: {
           'Content-Type': 'application/json'
         }
@@ -43,7 +43,7 @@ window.apiTokensComponent = function() {
     },
     async deleteToken(tokenId) {
       var self = this;
-      await fetch(`/api/v1/tokens/${tokenId}`, {
+      await fetch(`/api/tokens/${tokenId}`, {
         method: 'DELETE',
         headers: {
           'Content-Type': 'application/json'

--- a/web/src/js/pages/auditLogComponent.js
+++ b/web/src/js/pages/auditLogComponent.js
@@ -15,7 +15,7 @@ window.auditLogComponent = function() {
     },
 
     async getAuditLogs() {
-      const response = await fetch('/api/v1/audit-logs?start=' + (this.currentPage * 10), {
+      const response = await fetch('/api/audit-logs?start=' + (this.currentPage * 10), {
         headers: {
           'Content-Type': 'application/json'
         }

--- a/web/src/js/pages/createTokenForm.js
+++ b/web/src/js/pages/createTokenForm.js
@@ -27,7 +27,7 @@ window.createTokenForm = function() {
         name: this.formData.name,
       }
 
-      fetch('/api/v1/tokens', {
+      fetch('/api/tokens', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json'

--- a/web/src/js/pages/groupListComponent.js
+++ b/web/src/js/pages/groupListComponent.js
@@ -29,7 +29,7 @@ window.groupListComponent = function() {
     },
 
     async getGroups() {
-      const response = await fetch('/api/v1/groups', {
+      const response = await fetch('/api/groups', {
         headers: {
           'Content-Type': 'application/json'
         }
@@ -50,7 +50,7 @@ window.groupListComponent = function() {
     },
     async deleteGroup(groupId) {
       var self = this;
-      await fetch(`/api/v1/groups/${groupId}`, {
+      await fetch(`/api/groups/${groupId}`, {
         method: 'DELETE',
         headers: {
           'Content-Type': 'application/json'

--- a/web/src/js/pages/loginUserForm.js
+++ b/web/src/js/pages/loginUserForm.js
@@ -39,7 +39,7 @@ window.loginUserForm = function(redirect) {
         totp_code: this.formData.totp_code,
       }
 
-      fetch('/api/v1/auth/web', {
+      fetch('/api/auth/web', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json'

--- a/web/src/js/pages/rolesListComponent.js
+++ b/web/src/js/pages/rolesListComponent.js
@@ -29,7 +29,7 @@ window.rolesListComponent = function() {
     },
 
     async getRoles() {
-      const response = await fetch('/api/v1/roles', {
+      const response = await fetch('/api/roles', {
         headers: {
           'Content-Type': 'application/json'
         }
@@ -51,7 +51,7 @@ window.rolesListComponent = function() {
     },
     async deleteRole(roleId) {
       let self = this;
-      await fetch(`/api/v1/roles/${roleId}`, {
+      await fetch(`/api/roles/${roleId}`, {
         method: 'DELETE',
         headers: {
           'Content-Type': 'application/json'

--- a/web/src/js/pages/sessionsListComponent.js
+++ b/web/src/js/pages/sessionsListComponent.js
@@ -19,7 +19,7 @@ window.sessionsListComponent = function() {
     },
 
     async getSessions() {
-      const response = await fetch('/api/v1/sessions', {
+      const response = await fetch('/api/sessions', {
         headers: {
           'Content-Type': 'application/json'
         }
@@ -32,7 +32,7 @@ window.sessionsListComponent = function() {
     },
     async deleteSession(sessionId) {
       var self = this;
-      await fetch(`/api/v1/sessions/${sessionId}`, {
+      await fetch(`/api/sessions/${sessionId}`, {
         method: 'DELETE',
         headers: {
           'Content-Type': 'application/json'

--- a/web/src/js/pages/spaceForm.js
+++ b/web/src/js/pages/spaceForm.js
@@ -27,7 +27,7 @@ window.spaceForm = function(isEdit, spaceId, userId, preferredShell, forUserId, 
       focusElement('input[name="name"]');
 
       // Fetch the available templates
-      const templatesResponse = await fetch('/api/v1/templates', {
+      const templatesResponse = await fetch('/api/templates', {
         headers: {
           'Content-Type': 'application/json'
         }
@@ -36,7 +36,7 @@ window.spaceForm = function(isEdit, spaceId, userId, preferredShell, forUserId, 
       this.templates = templateList.templates;
 
       if(isEdit) {
-        const spaceResponse = await fetch('/api/v1/spaces/' + spaceId, {
+        const spaceResponse = await fetch('/api/spaces/' + spaceId, {
           headers: {
             'Content-Type': 'application/json'
           }
@@ -75,7 +75,7 @@ window.spaceForm = function(isEdit, spaceId, userId, preferredShell, forUserId, 
       }
 
       // Fetch the template to get the volume sizes
-      const templateResponse = await fetch('/api/v1/templates/' + this.template_id, {
+      const templateResponse = await fetch('/api/templates/' + this.template_id, {
         headers: {
           'Content-Type': 'application/json'
         }
@@ -143,7 +143,7 @@ window.spaceForm = function(isEdit, spaceId, userId, preferredShell, forUserId, 
       }
       this.loading = true;
 
-      fetch(isEdit ? '/api/v1/spaces/' + spaceId : '/api/v1/spaces', {
+      fetch(isEdit ? '/api/spaces/' + spaceId : '/api/spaces', {
           method: isEdit ? 'PUT' : 'POST',
           headers: {
             'Content-Type': 'application/json'
@@ -163,7 +163,7 @@ window.spaceForm = function(isEdit, spaceId, userId, preferredShell, forUserId, 
             // If start on create
             if (this.startOnCreate) {
               response.json().then((data) => {
-                fetch('/api/v1/spaces/' + data.space_id + '/start', {
+                fetch('/api/spaces/' + data.space_id + '/start', {
                   method: 'POST',
                   headers: {
                     'Content-Type': 'application/json'

--- a/web/src/js/pages/spacesListComponent.js
+++ b/web/src/js/pages/spacesListComponent.js
@@ -52,7 +52,7 @@ window.spacesListComponent = function(userId, username, forUserId, canManageSpac
 
     async init() {
       if(this.canManageSpaces || this.canTransferSpaces || this.canShareSpaces) {
-        const usersResponse = await fetch('/api/v1/users?state=active', {
+        const usersResponse = await fetch('/api/users?state=active', {
           headers: {
             'Content-Type': 'application/json'
           }
@@ -92,7 +92,7 @@ window.spacesListComponent = function(userId, username, forUserId, canManageSpac
       this.getSpaces();
     },
     async getSpaces() {
-      await fetch('/api/v1/spaces?user_id=' + this.forUserId, {
+      await fetch('/api/spaces?user_id=' + this.forUserId, {
         headers: {
           'Content-Type': 'application/json'
         }
@@ -161,7 +161,7 @@ window.spacesListComponent = function(userId, username, forUserId, canManageSpac
     },
     async startSpace(spaceId) {
       var self = this;
-      await fetch(`/api/v1/spaces/${spaceId}/start`, {
+      await fetch(`/api/spaces/${spaceId}/start`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'
@@ -201,7 +201,7 @@ window.spacesListComponent = function(userId, username, forUserId, canManageSpac
     },
     async stopSpace(spaceId) {
       var self = this;
-      await fetch(`/api/v1/spaces/${spaceId}/stop`, {
+      await fetch(`/api/spaces/${spaceId}/stop`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'
@@ -220,7 +220,7 @@ window.spacesListComponent = function(userId, username, forUserId, canManageSpac
     },
     async deleteSpace(spaceId) {
       let self = this;
-      await fetch(`/api/v1/spaces/${spaceId}`, {
+      await fetch(`/api/spaces/${spaceId}`, {
         method: 'DELETE',
         headers: {
           'Content-Type': 'application/json'
@@ -237,7 +237,7 @@ window.spacesListComponent = function(userId, username, forUserId, canManageSpac
     },
     async ceaseSharing(spaceId) {
       let self = this;
-      await fetch(`/api/v1/spaces/${spaceId}/share`, {
+      await fetch(`/api/spaces/${spaceId}/share`, {
         method: 'DELETE',
         headers: {
           'Content-Type': 'application/json'
@@ -302,8 +302,8 @@ window.spacesListComponent = function(userId, username, forUserId, canManageSpac
       // Transfer the space to the new user
       await fetch(
         this.isShare
-          ? `/api/v1/spaces/${this.chooseUser.space.space_id}/transfer`
-          : `/api/v1/spaces/${this.chooseUser.space.space_id}/share`,
+          ? `/api/spaces/${this.chooseUser.space.space_id}/transfer`
+          : `/api/spaces/${this.chooseUser.space.space_id}/share`,
       {
         method: 'POST',
         headers: {

--- a/web/src/js/pages/templateForm.js
+++ b/web/src/js/pages/templateForm.js
@@ -83,7 +83,7 @@ window.templateForm = function(isEdit, templateId) {
       }
       this.toHours.push('11:59pm');
 
-      const groupsResponse = await fetch('/api/v1/groups', {
+      const groupsResponse = await fetch('/api/groups', {
         headers: {
           'Content-Type': 'application/json'
         }
@@ -92,7 +92,7 @@ window.templateForm = function(isEdit, templateId) {
       this.groups = groupsList.groups;
 
       if(isEdit) {
-        const templateResponse = await fetch('/api/v1/templates/' + templateId, {
+        const templateResponse = await fetch('/api/templates/' + templateId, {
           headers: {
             'Content-Type': 'application/json'
           }
@@ -287,7 +287,7 @@ window.templateForm = function(isEdit, templateId) {
         data.is_manual = this.formData.is_manual;
       }
 
-      fetch(isEdit ? '/api/v1/templates/' + templateId : '/api/v1/templates', {
+      fetch(isEdit ? '/api/templates/' + templateId : '/api/templates', {
           method: isEdit ? 'PUT' : 'POST',
           headers: {
             'Content-Type': 'application/json'

--- a/web/src/js/pages/templateListComponent.js
+++ b/web/src/js/pages/templateListComponent.js
@@ -45,7 +45,7 @@ window.templateListComponent = function(canManageSpaces, location) {
 
     async getTemplates() {
       if(this.canManageSpaces) {
-        const usersResponse = await fetch('/api/v1/users?state=active', {
+        const usersResponse = await fetch('/api/users?state=active', {
           headers: {
             'Content-Type': 'application/json'
           }
@@ -54,7 +54,7 @@ window.templateListComponent = function(canManageSpaces, location) {
         this.users = usersList.users;
       }
 
-      const groupsResponse = await fetch('/api/v1/groups', {
+      const groupsResponse = await fetch('/api/groups', {
         headers: {
           'Content-Type': 'application/json'
         }
@@ -62,7 +62,7 @@ window.templateListComponent = function(canManageSpaces, location) {
       groupsList = await groupsResponse.json();
       this.groups = groupsList.groups;
 
-      const response = await fetch('/api/v1/templates', {
+      const response = await fetch('/api/templates', {
         headers: {
           'Content-Type': 'application/json'
         }
@@ -97,7 +97,7 @@ window.templateListComponent = function(canManageSpaces, location) {
     },
     async deleteTemplate(templateId) {
       let self = this;
-      await fetch(`/api/v1/templates/${templateId}`, {
+      await fetch(`/api/templates/${templateId}`, {
         method: 'DELETE',
         headers: {
           'Content-Type': 'application/json'
@@ -120,7 +120,7 @@ window.templateListComponent = function(canManageSpaces, location) {
       this.chooseUser.invalidUser = this.chooseUser.invalidTemplate = false;
 
       // Get the list of templates
-      await fetch('/api/v1/templates?user_id=' + this.chooseUser.forUserId, {
+      await fetch('/api/templates?user_id=' + this.chooseUser.forUserId, {
         headers: {
           'Content-Type': 'application/json'
         }

--- a/web/src/js/pages/templateVarListComponent.js
+++ b/web/src/js/pages/templateVarListComponent.js
@@ -29,7 +29,7 @@ window.templateVarListComponent = function() {
     },
 
     async getTemplateVars() {
-      const response = await fetch('/api/v1/templatevars', {
+      const response = await fetch('/api/templatevars', {
         headers: {
           'Content-Type': 'application/json'
         }
@@ -51,7 +51,7 @@ window.templateVarListComponent = function() {
     },
     async deleteTemplateVar(templateVarId) {
       var self = this;
-      await fetch(`/api/v1/templatevars/${templateVarId}`, {
+      await fetch(`/api/templatevars/${templateVarId}`, {
         method: 'DELETE',
         headers: {
           'Content-Type': 'application/json'

--- a/web/src/js/pages/tunnelsListComponent.js
+++ b/web/src/js/pages/tunnelsListComponent.js
@@ -13,7 +13,7 @@ window.tunnelsListComponent = function() {
     },
 
     async getTunnels() {
-      const response = await fetch('/api/v1/tunnels', {
+      const response = await fetch('/api/tunnels', {
         headers: {
           'Content-Type': 'application/json'
         }
@@ -25,7 +25,7 @@ window.tunnelsListComponent = function() {
     async terminateTunnel(tunnel) {
       let self = this;
 
-      fetch(`/api/v1/tunnels/${tunnel}`, {
+      fetch(`/api/tunnels/${tunnel}`, {
         method: 'DELETE',
         headers: {
           'Content-Type': 'application/json'

--- a/web/src/js/pages/usageComponent.js
+++ b/web/src/js/pages/usageComponent.js
@@ -24,7 +24,7 @@ window.usageComponent = function(userId) {
 
     async getUsage() {
       let self = this;
-      const quotaResponse = await fetch('/api/v1/users/' + userId + '/quota', {
+      const quotaResponse = await fetch('/api/users/' + userId + '/quota', {
         headers: {
           'Content-Type': 'application/json'
         }

--- a/web/src/js/pages/userForm.js
+++ b/web/src/js/pages/userForm.js
@@ -45,7 +45,7 @@ window.userForm = function(isEdit, userId, isProfile) {
     async initUsers() {
       focusElement('input[name="username"]');
 
-      const rolesResponse = await fetch('/api/v1/roles', {
+      const rolesResponse = await fetch('/api/roles', {
         headers: {
           'Content-Type': 'application/json'
         }
@@ -53,7 +53,7 @@ window.userForm = function(isEdit, userId, isProfile) {
       let roleList = await rolesResponse.json();
       this.roles = roleList.roles;
 
-      const groupsResponse = await fetch('/api/v1/groups', {
+      const groupsResponse = await fetch('/api/groups', {
         headers: {
           'Content-Type': 'application/json'
         }
@@ -62,7 +62,7 @@ window.userForm = function(isEdit, userId, isProfile) {
       this.groups = groupsList.groups;
 
       if(isEdit) {
-        const userResponse = await fetch('/api/v1/users/' + userId, {
+        const userResponse = await fetch('/api/users/' + userId, {
           headers: {
             'Content-Type': 'application/json'
           }
@@ -192,7 +192,7 @@ window.userForm = function(isEdit, userId, isProfile) {
         timezone: this.formData.timezone,
       };
 
-      fetch(isEdit ? '/api/v1/users/' + userId : '/api/v1/users', {
+      fetch(isEdit ? '/api/users/' + userId : '/api/users', {
           method: isEdit ? 'PUT' : 'POST',
           headers: {
             'Content-Type': 'application/json'

--- a/web/src/js/pages/userGroupForm.js
+++ b/web/src/js/pages/userGroupForm.js
@@ -22,7 +22,7 @@ window.userGroupForm = function(isEdit, groupId) {
       focusElement('input[name="name"]');
 
       if(isEdit) {
-        const groupResponse = await fetch('/api/v1/groups/' + groupId, {
+        const groupResponse = await fetch('/api/groups/' + groupId, {
           headers: {
             'Content-Type': 'application/json'
           }
@@ -84,7 +84,7 @@ window.userGroupForm = function(isEdit, groupId) {
         max_tunnels: parseInt(this.formData.max_tunnels),
       }
 
-      fetch(isEdit ? '/api/v1/groups/' + groupId : '/api/v1/groups', {
+      fetch(isEdit ? '/api/groups/' + groupId : '/api/groups', {
           method: isEdit ? 'PUT' : 'POST',
           headers: {
             'Content-Type': 'application/json'

--- a/web/src/js/pages/userListComponent.js
+++ b/web/src/js/pages/userListComponent.js
@@ -38,7 +38,7 @@ window.userListComponent = function() {
     },
 
     async getUsers() {
-      const rolesResponse = await fetch('/api/v1/roles', {
+      const rolesResponse = await fetch('/api/roles', {
         headers: {
           'Content-Type': 'application/json'
         }
@@ -46,7 +46,7 @@ window.userListComponent = function() {
       let roleList = await rolesResponse.json();
       this.roles = roleList.roles;
 
-      const groupsResponse = await fetch('/api/v1/groups', {
+      const groupsResponse = await fetch('/api/groups', {
         headers: {
           'Content-Type': 'application/json'
         }
@@ -54,7 +54,7 @@ window.userListComponent = function() {
       groupList = await groupsResponse.json();
       this.groups = groupList.groups;
 
-      const response = await fetch('/api/v1/users', {
+      const response = await fetch('/api/users', {
         headers: {
           'Content-Type': 'application/json'
         }
@@ -105,7 +105,7 @@ window.userListComponent = function() {
     },
     async deleteUser(userId) {
       var self = this;
-      await fetch(`/api/v1/users/${userId}`, {
+      await fetch(`/api/users/${userId}`, {
         method: 'DELETE',
         headers: {
           'Content-Type': 'application/json'
@@ -123,7 +123,7 @@ window.userListComponent = function() {
     },
     async stopSpaces(userId) {
       var self = this;
-      await fetch(`/api/v1/spaces/${userId}/stop-for-user`, {
+      await fetch(`/api/spaces/${userId}/stop-for-user`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'

--- a/web/src/js/pages/userRolesForm.js
+++ b/web/src/js/pages/userRolesForm.js
@@ -16,7 +16,7 @@ window.userRolesForm = function(isEdit, roleId) {
       focusElement('input[name="name"]');
 
       // fetch the permission list
-      const response = await fetch('/api/v1/permissions', {
+      const response = await fetch('/api/permissions', {
         headers: {
           'Content-Type': 'application/json'
         }
@@ -24,7 +24,7 @@ window.userRolesForm = function(isEdit, roleId) {
       this.permissions = await response.json();
 
       if(isEdit) {
-        const roleResponse = await fetch('/api/v1/roles/' + roleId, {
+        const roleResponse = await fetch('/api/roles/' + roleId, {
           headers: {
             'Content-Type': 'application/json'
           }
@@ -64,7 +64,7 @@ window.userRolesForm = function(isEdit, roleId) {
       }
       this.loading = true;
 
-      fetch(isEdit ? '/api/v1/roles/' + roleId : '/api/v1/roles', {
+      fetch(isEdit ? '/api/roles/' + roleId : '/api/roles', {
           method: isEdit ? 'PUT' : 'POST',
           headers: {
             'Content-Type': 'application/json'

--- a/web/src/js/pages/variableForm.js
+++ b/web/src/js/pages/variableForm.js
@@ -20,7 +20,7 @@ window.variableForm = function(isEdit, templateVarId) {
       focusElement('input[name="name"]');
 
       if(isEdit) {
-        const response = await fetch('/api/v1/templatevars/' + templateVarId, {
+        const response = await fetch('/api/templatevars/' + templateVarId, {
           headers: {
             'Content-Type': 'application/json'
           }
@@ -97,7 +97,7 @@ window.variableForm = function(isEdit, templateVarId) {
       }
       this.loading = true;
 
-      fetch(isEdit ? '/api/v1/templatevars/' + templateVarId : '/api/v1/templatevars', {
+      fetch(isEdit ? '/api/templatevars/' + templateVarId : '/api/templatevars', {
           method: isEdit ? 'PUT' : 'POST',
           headers: {
             'Content-Type': 'application/json'

--- a/web/src/js/pages/volumeForm.js
+++ b/web/src/js/pages/volumeForm.js
@@ -16,7 +16,7 @@ window.volumeForm = function(isEdit, volumeId) {
       focusElement('input[name="name"]');
 
       if(isEdit) {
-        const volumeResponse = await fetch('/api/v1/volumes/' + volumeId, {
+        const volumeResponse = await fetch('/api/volumes/' + volumeId, {
           headers: {
             'Content-Type': 'application/json'
           }
@@ -99,7 +99,7 @@ window.volumeForm = function(isEdit, volumeId) {
         data.local_container = this.formData.local_container;
       }
 
-      fetch(isEdit ? '/api/v1/volumes/' + volumeId : '/api/v1/volumes', {
+      fetch(isEdit ? '/api/volumes/' + volumeId : '/api/volumes', {
           method: isEdit ? 'PUT' : 'POST',
           headers: {
             'Content-Type': 'application/json'

--- a/web/src/js/pages/volumeListComponent.js
+++ b/web/src/js/pages/volumeListComponent.js
@@ -36,7 +36,7 @@ window.volumeListComponent = function() {
     },
 
     async getVolumes() {
-      const response = await fetch('/api/v1/volumes', {
+      const response = await fetch('/api/volumes', {
         headers: {
           'Content-Type': 'application/json'
         }
@@ -59,7 +59,7 @@ window.volumeListComponent = function() {
     },
     async deleteVolume(volumeId) {
     var self = this;
-      await fetch(`/api/v1/volumes/${volumeId}`, {
+      await fetch(`/api/volumes/${volumeId}`, {
         method: 'DELETE',
         headers: {
           'Content-Type': 'application/json'
@@ -76,7 +76,7 @@ window.volumeListComponent = function() {
     async startVolume(volumeId) {
       var self = this;
 
-      await fetch(`/api/v1/volumes/${volumeId}/start`, {
+      await fetch(`/api/volumes/${volumeId}/start`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'
@@ -107,7 +107,7 @@ window.volumeListComponent = function() {
       volume.stopping = true;
       volume.location = "";
 
-      await fetch(`/api/v1/volumes/${volumeId}/stop`, {
+      await fetch(`/api/volumes/${volumeId}/stop`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'

--- a/web/templates/initial-system-setup.tmpl
+++ b/web/templates/initial-system-setup.tmpl
@@ -92,7 +92,7 @@ function createInitialUserForm() {
         timezone: "UTC",
       }
 
-      fetch('/api/v1/users', {
+      fetch('/api/users', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json'


### PR DESCRIPTION
Refactor API endpoints to remove versioning from the URL and instead utilize a header for versioning.